### PR TITLE
Timed execution

### DIFF
--- a/lib/baku/system.rb
+++ b/lib/baku/system.rb
@@ -13,9 +13,11 @@ module Baku
         raise StandardError.new("Must set :world property of System.")
       end
       
-      entities = @world.entity_manager.get_entities(component_mask)
+      if enough_time_elapsed?(@world.delta_ms) 
+        entities = @world.entity_manager.get_entities(component_mask)
 
-      process_entities(entities)
+        process_entities(entities)
+      end
     end
 
     def process_entities(entities)
@@ -37,6 +39,10 @@ module Baku
 
     def retrieve_entities
       @world.entity_manager.get_entities(component_mask)
+    end
+
+    def enough_time_elapsed?(delta_ms)
+      true
     end
   end
 end

--- a/spec/features/engine_spec.rb
+++ b/spec/features/engine_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Baku::World do
     entity = world.create_entity
     entity.add_component(MockComponent.new)
     
-    world.update(1)
+    world.update(MockUpdateSystem::TIME_LIMIT)
 
     expect(entity.get_component(MockComponent).count).to eq(1)
   end

--- a/spec/support/mock_update_system.rb
+++ b/spec/support/mock_update_system.rb
@@ -1,9 +1,16 @@
 class MockUpdateSystem < Baku::System
+
+  TIME_LIMIT = 2
+
   def initialize
     super([MockComponent], :update)
   end
 
   def process_entity(entity, test)
     test.count += 1
+  end
+
+  def enough_time_elapsed?(delta_ms)
+    2 == delta_ms
   end
 end

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -15,14 +15,26 @@ RSpec.describe Baku::System do
     
     it "processes matching entities" do
       world.add_system(system)
-      
+
       entity = Baku::Entity.new
       entity.add_component(component)
       world.entity_manager.add_entity(entity)
-      
-      system.execute
+
+      world.update(MockUpdateSystem::TIME_LIMIT)
 
       expect(component.count).to eq(1)
+    end
+
+    it "won't process if not enoung time elapsed" do
+      world.add_system(system)
+
+      entity = Baku::Entity.new
+      entity.add_component(component)
+      world.entity_manager.add_entity(entity)
+
+      world.update(0)
+
+      expect(component.count).to eq(0)
     end
   end
 end

--- a/spec/world_spec.rb
+++ b/spec/world_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Baku::World do
     it "runs update systems correctly" do
       world.add_system(update_system)
       entity.add_component(component)
-      world.update(1)
+      world.update(MockUpdateSystem::TIME_LIMIT)
 
       expect(component.count).to eq(1)
     end


### PR DESCRIPTION
This PR makes it possible to check if enough time elapsed to execute a system.

Each system can optionally define a `def enough_time_elapsed?(delta_ms)` method in order to decide if it should be executed. 
