### PR TITLE
Don't override entities_by_component_mask

### DIFF
--- a/baku.gemspec
+++ b/baku.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry-byebug', '~> 3.5.0'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
 
   spec.add_dependency 'miru', '~> 0.1.0'
 end

--- a/lib/baku/entity_manager.rb
+++ b/lib/baku/entity_manager.rb
@@ -15,12 +15,12 @@ module Baku
     end
 
     def register_component_mask(component_mask)
-      @entities_by_component_mask[component_mask] = []
+      @entities_by_component_mask[component_mask] ||= []
     end
 
     def add_entity(entity)
       add_entity_to_matching_component_lists(entity)
-      
+
       entity.add_event_listener(
         :component_added,
         method(:on_entity_component_added)
@@ -40,7 +40,7 @@ module Baku
       entity.tags.each do |tag|
         @entities_by_tag[tag].delete(entity)
       end
-      
+
       entity.remove_event_listener(
         :component_added,
         method(:on_entity_component_added)
@@ -64,7 +64,7 @@ module Baku
     def get_entities_by_tag(tag)
       @entities_by_tag[tag] || []
     end
-    
+
     private
 
     def add_entity_to_matching_component_lists(entity)
@@ -88,11 +88,11 @@ module Baku
       @entities_by_component_mask.each do |component_mask, entities|
         old_match = component_mask.matches?(old_mask)
         new_match = component_mask.matches?(new_mask)
-        
+
         if old_match && !new_match
           entities.delete(entity)
         end
-      end      
+      end
     end
   end
 end

--- a/lib/baku/version.rb
+++ b/lib/baku/version.rb
@@ -1,3 +1,3 @@
 module Baku
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/entity_manager_spec.rb
+++ b/spec/entity_manager_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Baku::EntityManager do
 
   let(:match_entity) { Baku::Entity.new }
   let(:tagged_entity) { Baku::Entity.new([:some_tag]) }
-  
+
   before do
     entity_manager.register_component_mask(system.component_mask)
     match_entity.add_component(MockComponent.new)
@@ -30,6 +30,17 @@ RSpec.describe Baku::EntityManager do
     end
   end
 
+  describe "registering a component mask" do
+    before do
+      entity_manager.add_entity(match_entity)
+    end
+
+    it "doesn't override entities if the component mask has already been registered" do
+      expect { entity_manager.register_component_mask(system.component_mask) }
+        .not_to change { entity_manager.get_entities(system.component_mask) }
+    end
+  end
+
   describe "removing an entity" do
     before do
       entity_manager.add_entity(match_entity)
@@ -41,12 +52,12 @@ RSpec.describe Baku::EntityManager do
         to eq([])
     end
   end
-  
+
   describe "retrieving entities for a system" do
     let(:no_match_entity) { Baku::Entity.new }
-    
+
     before do
-      entity_manager.add_entity(no_match_entity)      
+      entity_manager.add_entity(no_match_entity)
     end
 
     it "returns empty array if no entities found" do
@@ -56,12 +67,12 @@ RSpec.describe Baku::EntityManager do
 
     it "only returns entities that match the system signature" do
       entity_manager.add_entity(match_entity)
-      
+
       expect(entity_manager.get_entities(system.component_mask)).
         to eq([match_entity])
     end
   end
-  
+
   describe "retrieving entities by tag" do
     let(:untagged_entity) { Baku::Entity.new }
     let(:other_tagged_entity) { Baku::Entity.new([:other_tag]) }
@@ -70,15 +81,15 @@ RSpec.describe Baku::EntityManager do
       entity_manager.add_entity(untagged_entity)
       entity_manager.add_entity(other_tagged_entity)
     end
-    
+
     it "returns empty array if no entities found" do
       expect(entity_manager.get_entities_by_tag(:empty_tag)).
         to eq([])
     end
-    
+
     it "returns only the entities with a matching tag" do
       entity_manager.add_entity(tagged_entity)
-      
+
       expect(entity_manager.get_entities_by_tag(:some_tag)).
         to eq([tagged_entity])
     end
@@ -91,7 +102,7 @@ RSpec.describe Baku::EntityManager do
     before do
       entity_manager.add_entity(entity)
     end
-    
+
     it "adds the entity to a matching component list" do
       entity.add_component(component)
       expect(entity_manager.get_entities(entity.component_mask)).
@@ -135,4 +146,4 @@ RSpec.describe Baku::EntityManager do
     end
   end
 end
- 
+


### PR DESCRIPTION
This fixes an issue with `register_component_mask` overriding `entities_by_component_mask` e.g when a new system is added after some entities have already been added to the world. This was a problem for me, as I wanted to use different systems in different "states" of the application and by adding/removing them dynamically.